### PR TITLE
added registeredRegistries as string[]

### DIFF
--- a/src/db-seeds/instance-config.ts
+++ b/src/db-seeds/instance-config.ts
@@ -46,6 +46,7 @@ export async function seedInitialInstanceConfig(prisma: PrismaClient) {
     quoteToDeliveryConversionType: EnumQuoteToDeliveryConversionServiceType.SIMPLE,
     details,
     updatedAt: new Date().toISOString(),
+    registeredRegistries: []
   }
 
   for (const [key, value] of Object.entries(initialConfigsData)) {

--- a/src/domains/config/instance-config.domain.service.ts
+++ b/src/domains/config/instance-config.domain.service.ts
@@ -55,6 +55,7 @@ export class InstanceConfigDomainService {
     const currency = await this.getCurrency()
     const details = await this.getDetails()
     const updatedAt = await this.getUpdatedAt()
+    const registeredRegistries = await this.getRegisteredRegistries()
 
     // Instance courier defaults
     const defaultCourierPayRate = await this.getDefaultCourierPayRate()
@@ -80,6 +81,7 @@ export class InstanceConfigDomainService {
       currency,
       details,
       updatedAt,
+      registeredRegistries,
     }
   }
 
@@ -151,6 +153,9 @@ export class InstanceConfigDomainService {
     }
     if (data.details) {
       await this.configRepository.saveByKey(ConfigKey.DETAILS, JSON.stringify(data.details))
+    }
+    if (data.registeredRegistries) {
+      await this.configRepository.saveByKey(ConfigKey.REGISTERED_REGISTRIES, JSON.stringify(data.registeredRegistries))
     }
 
     // Update the updated_at timestamp whenever config is changed
@@ -342,6 +347,25 @@ export class InstanceConfigDomainService {
     const updatedAt = await this.getConfigValueOrDefault(ConfigKey.UPDATED_AT, null)
 
     return updatedAt.value as string | null
+  }
+
+  async getRegisteredRegistries(): Promise<string[]> {
+    const registeredRegistries = await this.getConfigValueOrDefault(ConfigKey.REGISTERED_REGISTRIES, null)
+
+    if (!registeredRegistries.value) {
+      return []
+    }
+
+    const parsedRegistries =
+      typeof registeredRegistries.value === 'string'
+        ? JSON.parse(registeredRegistries.value)
+        : registeredRegistries.value
+
+    return Array.isArray(parsedRegistries) ? (parsedRegistries as string[]) : []
+  }
+
+  async setRegisteredRegistries(registries: string[]): Promise<void> {
+    await this.configRepository.saveByKey(ConfigKey.REGISTERED_REGISTRIES, JSON.stringify(registries))
   }
 
   async getConfigValueOrDefault(

--- a/src/rest-api/config/admin/dtos/instance-config-settings.dto.ts
+++ b/src/rest-api/config/admin/dtos/instance-config-settings.dto.ts
@@ -1,5 +1,4 @@
 import {
-  ConfigMap,
   EnumCourierCompensationCalculationType,
   EnumCourierDietaryRestrictions,
   EnumCourierMatcherType,
@@ -8,11 +7,12 @@ import {
   EnumDistanceUnit,
   EnumGeoCalculationType,
   EnumQuoteCalculationType,
+  InstanceConfigSettings,
   InstanceDetails,
 } from 'src/shared-types/index'
 import { ApiProperty } from '@nestjs/swagger'
 
-export class InstanceConfigSettingsDto implements ConfigMap {
+export class InstanceConfigSettingsDto {
   @ApiProperty({ enum: EnumCourierMatcherType })
   courierMatcherType: EnumCourierMatcherType
 
@@ -64,7 +64,10 @@ export class InstanceConfigSettingsDto implements ConfigMap {
   @ApiProperty({ type: String, nullable: true })
   updatedAt: string | null
 
-  constructor(data: ConfigMap) {
+  @ApiProperty({ type: String, isArray: true, nullable: true })
+  registeredRegistries: string[]
+
+  constructor(data: InstanceConfigSettings) {
     this.courierMatcherType = data.courierMatcherType as EnumCourierMatcherType
     this.quoteCalculationType = data.quoteCalculationType as EnumQuoteCalculationType
     this.geoCalculationType = data.geoCalculationType as EnumGeoCalculationType
@@ -85,5 +88,6 @@ export class InstanceConfigSettingsDto implements ConfigMap {
     this.defaultMaxWorkingHours = data.defaultMaxWorkingHours ? (data.defaultMaxWorkingHours as number) : null
     this.details = data.details && typeof data.details === 'object' ? (data.details as InstanceDetails) : null
     this.updatedAt = data.updatedAt ? (data.updatedAt as string) : null
+    this.registeredRegistries = Array.isArray(data.registeredRegistries) ? (data.registeredRegistries as string[]) : []
   }
 }

--- a/src/rest-api/config/admin/queries/instance-config-settings.admin.input.ts
+++ b/src/rest-api/config/admin/queries/instance-config-settings.admin.input.ts
@@ -96,4 +96,9 @@ export class InstanceConfigSettingsAdminInput implements InstanceConfigSettingsI
   @IsOptional()
   @IsObject()
   details?: InstanceDetails
+
+  @ApiProperty({ type: String, required: false, isArray: true })
+  @IsOptional()
+  @IsArray()
+  registeredRegistries?: string[]
 }

--- a/src/rest-api/config/admin/queries/instance-config-settings.input.ts
+++ b/src/rest-api/config/admin/queries/instance-config-settings.input.ts
@@ -27,4 +27,5 @@ export class InstanceConfigSettingsInput {
   distanceUnit?: EnumDistanceUnit
   currency?: EnumCurrency
   details?: InstanceDetails
+  registeredRegistries?: string[]
 }

--- a/src/shared-types/config.ts
+++ b/src/shared-types/config.ts
@@ -26,6 +26,7 @@ export type InstanceConfigSettings = {
   currency: EnumCurrency | null
   details: InstanceDetails
   updatedAt: string | null
+  registeredRegistries: string[]
 }
 
 export type InstanceDetails = {
@@ -83,6 +84,9 @@ export enum ConfigKey {
   MAX_DRIFT_DISTANCE = 'maxDriftDistance',
   DETAILS = 'details',
   UPDATED_AT = 'updatedAt',
+  REGISTERED_REGISTRIES = 'registeredRegistries',
 }
 
-export type ConfigMap = { [key in ConfigKey]?: string | number | boolean | null | InstanceDetails }
+export type ConfigMap = {
+  [key in ConfigKey]?: string | number | boolean | null | InstanceDetails | string[]
+}


### PR DESCRIPTION
Added attribute `registeredRegistries` to Config table as a `string[]`, which stores the links of the registries they have registered in. That way each instance can keep track!