### PR TITLE
fix so that /metadata sends combined geo data so that registry can correctly add to postGIS

### DIFF
--- a/src/rest-api/config/public/config.public.rest-api.controller.ts
+++ b/src/rest-api/config/public/config.public.rest-api.controller.ts
@@ -5,6 +5,7 @@ import { ConfigDomainService } from '../../../domains/config/config.domain.servi
 import { UserDomainService } from '../../../domains/user/user.domain.service'
 import { MetadataPublicDto } from './dtos/metadata.public.dto'
 import { Public } from '../../../decorators/public.decorator'
+import { normalizeRegionForPostGIS } from '../../../utils/geoJsonUtils'
 
 @swagger.ApiTags('config')
 @common.Controller(`${PUBLIC_API_V1_PREFIX}/config`)
@@ -34,6 +35,11 @@ export class ConfigPublicRestApiController {
 
     if (instanceConfig.details.link !== instanceLink) {
       throw new common.NotFoundException('Instance not found')
+    }
+
+    // Normalize region for PostGIS
+    if (instanceConfig.details.region) {
+      instanceConfig.details.region = normalizeRegionForPostGIS(instanceConfig.details.region)
     }
 
     return new MetadataPublicDto(instanceConfig, userCount)

--- a/src/rest-api/config/public/instance-details.public.rest-api.controller.ts
+++ b/src/rest-api/config/public/instance-details.public.rest-api.controller.ts
@@ -6,6 +6,7 @@ import { ConfigDomainService } from '../../../domains/config/config.domain.servi
 import { UserDomainService } from '../../../domains/user/user.domain.service'
 import { MetadataPublicDto } from './dtos/metadata.public.dto'
 import { Public } from '../../../decorators/public.decorator'
+import { normalizeRegionForPostGIS } from '../../../utils/geoJsonUtils'
 
 @swagger.ApiTags('public')
 @common.Controller('')
@@ -33,6 +34,11 @@ export class InstanceDetailsPublicRestApiController {
 
     if (!instanceConfig.details) {
       throw new common.NotFoundException('Instance details not found')
+    }
+
+    // Normalize region for PostGIS
+    if (instanceConfig.details.region) {
+      instanceConfig.details.region = normalizeRegionForPostGIS(instanceConfig.details.region)
     }
 
     return new MetadataPublicDto(instanceConfig, userCount)

--- a/src/utils/geoJsonUtils.ts
+++ b/src/utils/geoJsonUtils.ts
@@ -1,0 +1,47 @@
+/**
+ * Converts a FeatureCollection to a single Geometry (Polygon or MultiPolygon)
+ * suitable for PostGIS storage via ST_GeomFromGeoJSON
+ */
+export function normalizeRegionForPostGIS(region: any): any {
+  if (!region || typeof region !== 'object') {
+    return region
+  }
+
+  // Handle FeatureCollection - extract and merge geometries
+  if (region.type === 'FeatureCollection' && region.features?.length > 0) {
+    const geometries = region.features
+      .map((f: any) => f.geometry)
+      .filter((g: any) => g) // Filter out null geometries
+
+    if (geometries.length === 0) {
+      return null
+    }
+
+    if (geometries.length === 1) {
+      // Single geometry - return as-is
+      return geometries[0]
+    }
+
+    // Multiple geometries - check if all are Polygons
+    const allPolygons = geometries.every((g: any) => g.type === 'Polygon')
+
+    if (allPolygons) {
+      // Create a MultiPolygon from all polygon geometries
+      return {
+        type: 'MultiPolygon',
+        coordinates: geometries.map((g: any) => g.coordinates),
+      }
+    }
+
+    // Mixed geometry types - fall back to first geometry
+    return geometries[0]
+  }
+
+  // Handle single Feature - extract geometry
+  if (region.type === 'Feature') {
+    return region.geometry
+  }
+
+  // Assume it's already a geometry object (Polygon, MultiPolygon, etc.)
+  return region
+}


### PR DESCRIPTION
Database stores operating region as a `FeatureCollection` so that on adminweb can still edit each polygon. However, registry as a PostGIS database requires either a `Polygon` or `MultiPolygon`. Adminweb thus has a util function that turns a `FeatureCollection` into a `Polygon` or `MultiPolygon` upon registration to registry. However, backend also needs this function so that when registry pulls new data by using the `/metadata` endpoint, it can save new data to registry.